### PR TITLE
Remove deprecated pytest marks

### DIFF
--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -306,8 +306,6 @@ def bob(reactor, temp_dir, introducer_furl, flog_gatherer, storage_nodes, reques
 
 
 @pytest.fixture(scope='session')
-@pytest.mark.skipif(sys.platform.startswith('win'),
-                    'Tor tests are unstable on Windows')
 def chutney(reactor, temp_dir: str) -> FilePath:
     """
     Install the Chutney software that is required to run a small local Tor grid.
@@ -337,8 +335,6 @@ class ChutneyTorNetwork:
 
 
 @pytest.fixture(scope='session')
-@pytest.mark.skipif(sys.platform.startswith('win'),
-                    reason='Tor tests are unstable on Windows')
 def tor_network(reactor, temp_dir, chutney, request):
     """
     Build a basic Tor network.


### PR DESCRIPTION
Also attempting to see if `test-result.yml` workflow works, because https://github.com/dorny/test-reporter says that the workflow needs to be in default branch.  It is on the default branch of my fork, as of https://github.com/sajith/tahoe-lafs/commit/63124b6ce74de1a1124cf76ec35fc271fda652ee.